### PR TITLE
Use Octokit for as much as possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "http://rubygems.org"
 
-gem "json",                 "1.7.7"
 gem "sinatra",              "~> 1.4"
 gem "sinatra-contrib",      "~> 1.4"
 gem "contribution-checker", "~> 0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
       octokit (~> 3.1)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    json (1.7.7)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     octokit (3.1.2)
@@ -38,7 +37,6 @@ PLATFORMS
 
 DEPENDENCIES
   contribution-checker (~> 0.1)
-  json (= 1.7.7)
   octokit (~> 3.1)
   sinatra (~> 1.4)
   sinatra-contrib (~> 1.4)

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,4 @@
 require "sinatra"
-require "json"
 require "sinatra/json"
 require "contribution-checker"
 require "octokit"


### PR DESCRIPTION
Removes dependencies on the `rest-client` and `json` gems, and uses `octokit` instead.
