### PR TITLE
Show email used to author commit

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -17,14 +17,9 @@ body {
 #results-lead span {
   padding: 2px 4px;
 }
-#results .octicon {
-  width: 12px;
-}
-#results table td span {
-  margin-right: 12px;
-}
 .table td:first-child {
   padding-left: 15px;
+  width: 36px;
 }
 .flash {
   color: #f90;

--- a/views/index.erb
+++ b/views/index.erb
@@ -55,24 +55,20 @@
         </div>
         <table class="table table-condensed table-responsive">
           <tr class="{{#if and_criteria.commit_in_valid_branch}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if and_criteria.commit_in_valid_branch}}check{{else}}x{{/if}}"></span>Is the commit in the default or gh-pages branch?
-            </td>
+            <td><span class="octicon octicon-{{#if and_criteria.commit_in_valid_branch}}check{{else}}x{{/if}}"></span></td>
+            <td>Is the commit in the default or gh-pages branch?</td>
           </tr>
           <tr class="{{#if and_criteria.commit_in_last_year}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if and_criteria.commit_in_last_year}}check{{else}}x{{/if}}"></span>Was the commit authored in the last year?
-            </td>
+            <td><span class="octicon octicon-{{#if and_criteria.commit_in_last_year}}check{{else}}x{{/if}}"></span></td>
+            <td>Was the commit authored in the last year?</td>
           </tr>
           <tr class="{{#if and_criteria.repo_not_a_fork}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if and_criteria.repo_not_a_fork}}check{{else}}x{{/if}}"></span>Is the repository containing the commit <em>not</em> a fork?
-            </td>
+            <td><span class="octicon octicon-{{#if and_criteria.repo_not_a_fork}}check{{else}}x{{/if}}"></span></td>
+            <td>Is the repository containing the commit <em>not</em> a fork?</td>
           </tr>
           <tr class="{{#if and_criteria.commit_email_linked_to_user}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if and_criteria.commit_email_linked_to_user}}check{{else}}x{{/if}}"></span>Have you added the email address used to author the commit to your GitHub account?
-            </td>
+            <td><span class="octicon octicon-{{#if and_criteria.commit_email_linked_to_user}}check{{else}}x{{/if}}"></span></td>
+            <td>Have you added the email used to author the commit ({{and_criteria.commit_email}}) to your GitHub account?</td>
           </tr>
         </table>
       </div>
@@ -83,24 +79,20 @@
         </div>
         <table class="table table-condensed table-responsive">
           <tr class="{{#if or_criteria.user_has_starred_repo}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if or_criteria.user_has_starred_repo}}check{{else}}x{{/if}}"></span>Have you starred the repository containing the commit?
-            </td>
+            <td><span class="octicon octicon-{{#if or_criteria.user_has_starred_repo}}check{{else}}x{{/if}}"></span></td>
+            <td>Have you starred the repository containing the commit?</td>
           </tr>
           <tr class="{{#if or_criteria.user_can_push_to_repo}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if or_criteria.user_can_push_to_repo}}check{{else}}x{{/if}}"></span>Do you have push access to the repository?
-            </td>
+            <td><span class="octicon octicon-{{#if or_criteria.user_can_push_to_repo}}check{{else}}x{{/if}}"></span></td>
+            <td>Do you have push access to the repository?</td>
           </tr>
           <tr class="{{#if or_criteria.user_is_repo_org_member}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if or_criteria.user_is_repo_org_member}}check{{else}}x{{/if}}"></span>Are you a member of the organization that owns the repository?
-            </td>
+            <td><span class="octicon octicon-{{#if or_criteria.user_is_repo_org_member}}check{{else}}x{{/if}}"></span></td>
+            <td>Are you a member of the organization that owns the repository?</td>
           </tr>
           <tr class="{{#if or_criteria.user_has_fork_of_repo}}success{{else}}danger{{/if}}">
-            <td>
-              <span class="octicon octicon-{{#if or_criteria.user_has_fork_of_repo}}check{{else}}x{{/if}}"></span>Do you own a fork of the repository containing the commit?
-            </td>
+            <td><span class="octicon octicon-{{#if or_criteria.user_has_fork_of_repo}}check{{else}}x{{/if}}"></span>
+            <td>Do you own a fork of the repository containing the commit?</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
Show email used to author commit as part of the "and criteria":

![show-email](https://cloud.githubusercontent.com/assets/65057/3351995/bad11c56-fa2b-11e3-92d4-e0cba421f454.png)

Enabled by https://github.com/jdennes/contribution-checker/pull/4

Branch deployed: http://contribution-checker.herokuapp.com/

There are also some other markup and style changes included to simplify and improve the results tables (particularly when viewed on a mobile device).
