### PR TITLE
Request the read:org scope too

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -14,7 +14,7 @@ end
 
 # Ask the user to authorise the app.
 def authenticate!
-  redirect "https://github.com/login/oauth/authorize?scope=user:email&client_id=#{CLIENT_ID}"
+  redirect "https://github.com/login/oauth/authorize?scope=user:email,read:org&client_id=#{CLIENT_ID}"
 end
 
 # Check whether the user has an access token.

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -16,7 +16,7 @@ describe "The Contribution Checker app" do
 
         expect(last_response.status).to eq(302)
         expect(last_response.location).to \
-          eq("https://github.com/login/oauth/authorize?scope=user:email&client_id=myclientid")
+          eq("https://github.com/login/oauth/authorize?scope=user:email,read:org&client_id=myclientid")
       end
     end
 
@@ -32,7 +32,7 @@ describe "The Contribution Checker app" do
         expect(last_request.env["rack.session"][:access_token]).to eq(nil)
         expect(last_response.status).to eq(302)
         expect(last_response.location).to \
-          eq("https://github.com/login/oauth/authorize?scope=user:email&client_id=myclientid")
+          eq("https://github.com/login/oauth/authorize?scope=user:email,read:org&client_id=myclientid")
       end
     end
 

--- a/spec/fixtures/access_token.json
+++ b/spec/fixtures/access_token.json
@@ -1,5 +1,5 @@
 {
   "access_token": "myaccesstoken",
-  "scope": "user:email",
+  "scope": "user:email,read:org",
   "token_type": "bearer"
 }


### PR DESCRIPTION
Previously, the check for organization membership was only returning true when the user was a public member of an organization.

Requesting the `read:org` scope fixes the problem, so that users with private membership are still detected as members of an organization.

What do you think @izuzak? :smile: 
