### PR TITLE
Better default branch copy

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -90,6 +90,8 @@ post "/" do
       result[:or_criteria][:user_can_push_to_repo] ||
       result[:or_criteria][:user_is_repo_org_member] ||
       result[:or_criteria][:user_has_fork_of_repo]
+    result[:default_branch_is_gh_pages] =
+      result[:and_criteria][:default_branch] == "gh-pages"
 
   rescue ContributionChecker::InvalidCommitUrlError => err
     return json :error_message => err

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -128,6 +128,7 @@ describe "The Contribution Checker app" do
         expect(last_response.body).to include("\"commit_url\":\"#{commit_url}\"")
         expect(last_response.body).to include("\"and_criteria_met\":true")
         expect(last_response.body).to include("\"or_criteria_met\":true")
+        expect(last_response.body).to include("\"default_branch_is_gh_pages\":false")
       end
     end
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -37,7 +37,9 @@
   <table class="table table-condensed table-responsive">
     <tr class="{{#if and_criteria.commit_in_valid_branch}}success{{else}}danger{{/if}}">
       <td><span class="octicon octicon-{{#if and_criteria.commit_in_valid_branch}}check{{else}}x{{/if}}"></span></td>
-      <td>Is the commit in the <em>{{and_criteria.default_branch}}</em> or <em>gh-pages</em> branch?</td>
+      <td>Is the commit in the <em>{{and_criteria.default_branch}}</em>
+        {{#unless default_branch_is_gh_pages}}or <em>gh-pages</em>{{/unless}} branch?
+      </td>
     </tr>
     <tr class="{{#if and_criteria.commit_in_last_year}}success{{else}}danger{{/if}}">
       <td><span class="octicon octicon-{{#if and_criteria.commit_in_last_year}}check{{else}}x{{/if}}"></span></td>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -31,10 +31,8 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
       ga('create', 'UA-3769691-49', 'auto');
       ga('send', 'pageview');
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
Just a little :memo: :sparkles::

When a repository's default branch is `gh-pages`, don't show "Is the commit in the gh-pages or gh-pages branch?".

Prefer this:

![single](https://cloud.githubusercontent.com/assets/65057/5696382/28f9e382-99cf-11e4-874b-18aae7063764.png)

over this:

![double](https://cloud.githubusercontent.com/assets/65057/5696383/2d7dc036-99cf-11e4-913a-390da52074d8.png)
